### PR TITLE
Add server-side rendering example with React Router 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,21 @@ export default tseslint.config({
   },
 })
 ```
+
+## Server-side data fetching with React Router 7
+
+The `src/ssr` folder demonstrates how to load data on the server using React Router 7.
+Routes in `src/ssr/routes.tsx` use `loader` functions that fetch data from the PokéAPI.
+`src/ssr/server.tsx` creates a small Node server which renders the router on the server
+via `createStaticHandler`, `createStaticRouter` and `<StaticRouterProvider>`.
+Example pages `ListSsrPage` and `DetailSsrPage` consume the loaded data using
+`useLoaderData`.
+
+To run this example you need Node 18+ with native `fetch` available. Start the server
+with:
+
+```bash
+node src/ssr/server.tsx
+```
+
+Then open http://localhost:5173/pokemon in your browser to see the server rendered output.

--- a/src/pages/details/DetailSsrPage.tsx
+++ b/src/pages/details/DetailSsrPage.tsx
@@ -1,0 +1,13 @@
+import { useLoaderData } from "react-router";
+import { PokemonDetailDto } from "../../api/pokeApi";
+
+export function DetailSsrPage() {
+  const data = useLoaderData() as PokemonDetailDto;
+  const pokemonName = data.name;
+  return (
+    <div>
+      <span>{pokemonName}</span>
+      <img src={data.sprites.front_shiny} alt={pokemonName} />
+    </div>
+  );
+}

--- a/src/pages/list/ListSsrPage.tsx
+++ b/src/pages/list/ListSsrPage.tsx
@@ -1,0 +1,8 @@
+import { useLoaderData } from "react-router";
+import { PokemonListDto } from "../../api/pokeApi";
+import { PokeList } from "../../components/poke-list/PokeList";
+
+export function ListSsrPage() {
+  const data = useLoaderData() as PokemonListDto;
+  return <PokeList pokemons={data?.results ?? []} />;
+}

--- a/src/ssr/routes.tsx
+++ b/src/ssr/routes.tsx
@@ -1,0 +1,28 @@
+import { Layout } from "../components/layout/Layout";
+import { ListSsrPage } from "../pages/list/ListSsrPage";
+import { DetailSsrPage } from "../pages/details/DetailSsrPage";
+import { fetcher } from "../api/fetcher";
+import { PokemonListDto, PokemonDetailDto } from "../api/pokeApi";
+
+export const routes = [
+  {
+    path: "/",
+    element: <Layout />,
+    children: [
+      {
+        path: "pokemon",
+        loader: () =>
+          fetcher<PokemonListDto>("https://pokeapi.co/api/v2/pokemon"),
+        Component: ListSsrPage,
+      },
+      {
+        path: "pokemon/:pokemonName",
+        loader: ({ params }) =>
+          fetcher<PokemonDetailDto>(
+            `https://pokeapi.co/api/v2/pokemon/${params.pokemonName}`
+          ),
+        Component: DetailSsrPage,
+      },
+    ],
+  },
+];

--- a/src/ssr/server.tsx
+++ b/src/ssr/server.tsx
@@ -1,0 +1,41 @@
+import { createServer } from "node:http";
+import React from "react";
+import { renderToString } from "react-dom/server";
+import {
+  createStaticHandler,
+  createStaticRouter,
+  StaticRouterProvider,
+} from "react-router-dom/server";
+import { routes } from "./routes";
+
+const handler = createStaticHandler(routes);
+
+const server = createServer(async (req, res) => {
+  try {
+    const request = new Request(`http://localhost${req.url}`, {
+      method: req.method,
+      headers: req.headers as any,
+    });
+    const context = await handler.query(request);
+    if (context instanceof Response) {
+      res.statusCode = context.status;
+      res.end(await context.text());
+      return;
+    }
+    const router = createStaticRouter(handler.dataRoutes, context);
+    const markup = renderToString(
+      <StaticRouterProvider router={router} context={context} />
+    );
+    res.statusCode = 200;
+    res.setHeader("Content-Type", "text/html");
+    res.end(`<!DOCTYPE html><html><head><meta charset="UTF-8" /></head><body><div id="root">${markup}</div><script type="module" src="/src/main.tsx"></script></body></html>`);
+  } catch (err) {
+    console.error(err);
+    res.statusCode = 500;
+    res.end("Internal Server Error");
+  }
+});
+
+server.listen(5173, () => {
+  console.log("SSR server running at http://localhost:5173");
+});


### PR DESCRIPTION
## Summary
- add ListSsrPage and DetailSsrPage using `useLoaderData`
- provide SSR route configuration and basic Node server
- document how to run the SSR example

## Testing
- `npm test` *(fails: Cannot find package 'jsdom')*